### PR TITLE
Remove exe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,4 +31,3 @@ jobs:
         with:
           files: |
             RegionChanger.py
-            build/RegionChanger.exe

--- a/README.md
+++ b/README.md
@@ -10,14 +10,30 @@ Region Changer works by modifying your system's hosts file to block specific AWS
 ## Features
 - Lightweight: Minimalist design and low resource usage.
 - Custom Region Selection: Choose your preferred server region with ease.
-- No VPN Required: Avoid the hassle and potential slowdowns of a VPN connection.
-- Quick Setup: One-click functionality to switch regions or reset to default.
+- No VPN Required: Avoid the hassle, cost, and higher ping of a VPN connection.
+
+## Setup
+### 1. Install Python
+If you don't have Python installed:
+- Go to (https://www.python.org/downloads/) and download the latest version for your operating system.
+- Install Python
+
+### 2. Download the script
+https://github.com/snoggles/Dead-by-Daylight-Region-Changer/releases/latest/download/RegionChanger.py
+
+### 3. Create a Shortcut
+1. Right click > New Shortcut > `python.exe C:\path\to\RegionChanger.py` > Finish
+2. Right click shortcut > Properties > Shortcut > Advanced > Run as administrator > OK > OK
+3. Rename shortcut to something like `Region Changer`
+4. Move shortcut to `C:\ProgramData\Microsoft\Windows\Start Menu\Programs` to make it available on the start menu
 
 ## How to Use
-1. Run [RegionChanger.exe](https://github.com/snoggles/Dead-by-Daylight-Region-Changer/releases/latest/download/RegionChanger.exe) (it asks to run as administrator to modify the hosts file).
+1. Run the [RegionChanger.py](https://github.com/snoggles/Dead-by-Daylight-Region-Changer/releases/latest/download/RegionChanger.exe) shortcut (it asks to run as administrator to modify the hosts file).
 2. Select the region you want from the list.
 3. The tool will automatically block other regions, forcing Dead by Daylight to connect to your selected region.
 4. If you wish to reset to the default settings, use the Cleanup option to unblock all regions.
+
+---
 
 ## Limitations
 - This tool modifies the hosts file. While this is safe, antivirus software may flag it as suspicious — this is a false positive.
@@ -27,30 +43,10 @@ Region Changer works by modifying your system's hosts file to block specific AWS
 - This software is not affiliated with or endorsed by Dead by Daylight or AWS.
 - Use at your own risk. Ensure you understand how modifying your hosts file affects your system.
 
----
+## Building an exe (not recommended)
+There are instructions to [build an exe](developing.md), but most virus scanners will automatically delete it, so this is not recommended.
 
-## Running from source
-
-Instead of [running the .exe](#how-to-use), you can run the [RegionChanger.py](https://github.com/snoggles/Dead-by-Daylight-Region-Changer/releases/latest/download/RegionChanger.py) script directly if you [install python](#1-install-python).
-
-### Benefits
-- Faster startup time.
-- Antivirus will not interfere with it.
-- You can easily see what it's doing and make changes.
-
-### 1. Install Python
-If you don't have Python installed:
-- Go to (https://www.python.org/downloads/) and download the latest version for your operating system.
-- Install Python
-
-### 2. Create a Shortcut
-1. Right click > New Shortcut > `python.exe C:\path\to\RegionChanger.py` > Finish
-2. Right click shortcut > Properties > Shortcut > Advanced > Run as administrator > OK > OK
-3. Rename shortcut to something like `Region Changer`
-4. Move shortcut to `C:\ProgramData\Microsoft\Windows\Start Menu\Programs` to make it available on the start menu
-
----
-
+## Support
 If you have feedback, questions, or encounter issues, feel free to reach out!
 
 Happy gaming! 🎮


### PR DESCRIPTION
Removes .exe release.

The exe was a constant source of support headaches as windows antivirus would near-silently delete the file.