### PR TITLE
Add cleanup for other region changers.

### DIFF
--- a/RegionChanger.py
+++ b/RegionChanger.py
@@ -69,10 +69,17 @@ def remove_all_overrides():
 
     def is_gamelift_line(line):
         # This the traditional pattern used < 8.4.0
-        pattern1 = r".*\sgamelift\.[^.]+\.amazonaws\.com$"
+        # There are a few flavors:
+        # - gamelift.us-east-1.amazonaws.com (this is the common one)
+        # - ec2.ap-east-1.amazonaws.com (seems unused as of 9.3.0)
+        # - gamelift.cn-northwest-1.amazonaws.com.cn (I'm not sure if this is real.)
+        pattern1 = r".*\s(gamelift|ec2)\.[^.]+\.amazonaws\.com[^\s]*$"
+
         # The .api.aws hostnames were added briefly in 8.4.0, then reverted.
         # Starting in 8.5.2, the .api.aws seem to be turned on and off intermittently.
+        # As of 9.3.0, the .api.aws hostnames are the only ones used.
         pattern2 = r".*\sgamelift-ping\.[^.]+\.api\.aws$"
+
         return re.match(pattern1, line) or re.match(pattern2, line)
 
     # Filter out lines containing domains to remove


### PR DESCRIPTION
## Summary
[Make Your Choice](https://github.com/laewliet/make-your-choice) adds the following hosts file entries:
- gamelift.cn-north-1.amazonaws.com.cn
- gamelift.cn-northwest-1.amazonaws.com.cn
- ec2.ap-east-1.amazonaws.com

This PR strips them when we make changes to avoid confusion.

## *.amazonaws.com.cn entries
Despite being marked [stable=true](https://github.com/laewliet/make-your-choice/blob/761beaf83bac8d7b97511bab53369a889d2d6592/win/Form1.cs#L59-L60):
- they do not seem available for matching with crossplay off
- they do not seem available for placement with custom matches + bots
- I don't see DNS queries to them during game startup.
- I *did* match with one user in normal lobbies who claimed to be Chinese, but I didn't start the match to check ping.

## ec2.ap-east-1.amazonaws.com
- [Make Your Choice claims this is Hong Kong](https://github.com/laewliet/make-your-choice/blob/761beaf83bac8d7b97511bab53369a889d2d6592/win/Form1.cs#L53). I've seen this hostname previously, but I don't see DNS lookups to it anymore.
- I *do* see DNS lookups for gamelift-ping.ap-east-1.api.aws, which leads me to believe this is the correct hostname now.

## Observed DNS lookups (9.3.2)
These are the DNS queries I currently see at DBD startup during the Calculating Latency phase:
```
A gamelift-ping.ap-east-1.api.aws
A gamelift-ping.ap-northeast-1.api.aws
A gamelift-ping.ap-northeast-2.api.aws
A gamelift-ping.ap-south-1.api.aws
A gamelift-ping.ap-southeast-1.api.aws
A gamelift-ping.ap-southeast-2.api.aws
A gamelift-ping.ca-central-1.api.aws
A gamelift-ping.eu-central-1.api.aws
A gamelift-ping.eu-west-1.api.aws
A gamelift-ping.eu-west-2.api.aws
A gamelift-ping.sa-east-1.api.aws
A gamelift-ping.us-east-1.api.aws
A gamelift-ping.us-east-2.api.aws
A gamelift-ping.us-west-1.api.aws
A gamelift-ping.us-west-2.api.aws
```

cc: @laewliet
